### PR TITLE
Fix noir compilation issues

### DIFF
--- a/circuits/helpers/Nargo.toml
+++ b/circuits/helpers/Nargo.toml
@@ -2,6 +2,6 @@
 name = "helpers"
 type = "lib"
 authors = [""]
-compiler_version = "0.9.0"
+compiler_version = ">=0.9.0"
 
 [dependencies]

--- a/circuits/helpers/src/addressing.nr
+++ b/circuits/helpers/src/addressing.nr
@@ -30,7 +30,7 @@
 pub fn wrapping_add_u16(a: Field, b: Field) -> Field {
     let max = 65535;
 
-    if ((a as u32) + (b as u32)) > 65535 {
+    if ((a as u32) + (b as u32)) > max {
         (a + b) - 65535
     } else {
         a + b
@@ -40,7 +40,7 @@ pub fn wrapping_add_u16(a: Field, b: Field) -> Field {
 
 pub fn acc(
     op_sorted_addr: [Field; 1],
-    op_sorted_val: [Field; 1],
+    _op_sorted_val: [Field; 1],
     op_sorted_op_rw: [Field; 1],
 ) {
     // also kind of a do nothing mode
@@ -52,7 +52,7 @@ pub fn acc(
 
 pub fn imp(
     op_sorted_addr: [Field; 2],
-    op_sorted_val: [Field; 2],
+    _op_sorted_val: [Field; 2],
     op_sorted_op_rw: [Field; 2],
 ) {
     //kind of a do nothing mode

--- a/circuits/helpers/src/addressing.nr
+++ b/circuits/helpers/src/addressing.nr
@@ -30,7 +30,7 @@
 fn wrapping_add_u16(a: Field, b: Field) -> Field {
     let max = 65535;
 
-    if ((a as u16) + (b as u16)) > 65535 {
+    if ((a as u32) + (b as u32)) > 65535 {
         (a + b) - 65535
     } else {
         a + b
@@ -239,7 +239,7 @@ fn abx_aby(
     // add value of x or y to addr
     let abs_addr = wrapping_add_u16(joint as Field, index);
     // value of Addr is addr + x or y
-    let data_addr = ((joint as u16) & 65280) as u16 | ((abs_addr as u16) & 255) as u16;
+    let data_addr = ((joint as u32) & 65280) as u32 | ((abs_addr as u32) & 255) as u32;
     // read addr & 0xFF00 | Addr & 0x00FF and return as Value
     assert(op_sorted_addr[7] == data_addr as Field);
     assert(op_sorted_op_rw[7] == 0);
@@ -279,7 +279,7 @@ fn ind(
     // addr is hi << 8 | lo
     let joint_addr = (hi as u8) << 8 | (lo as u8);
     // if addr & 0xFF  == 0xFF
-    if ((joint_addr as u16) & 255) == 255 {
+    if ((joint_addr as u32) & 255) == 255 {
         // read value from addr lo byte
         // read value from addr hi byte
         // return value from hi << 8 | value from lo as Addr
@@ -287,7 +287,7 @@ fn ind(
         assert(op_sorted_op_rw[6] == 0);
         lo = op_sorted_val[6];
 
-        assert(op_sorted_addr[7] == ((joint_addr as u16) & 65280) as Field);
+        assert(op_sorted_addr[7] == ((joint_addr as u32) & 65280) as Field);
         assert(op_sorted_op_rw[7] == 0);
         hi = op_sorted_val[7];
 
@@ -343,7 +343,7 @@ fn idx(
         assert(op_sorted_op_rw[5] == 0);
         let hi = op_sorted_val[6];
         // return Addr as hi << 8 | lo
-        ((hi as u16) << 8 | (lo as u16)) as Field
+        ((hi as u32) << 8 | (lo as u32)) as Field
 }
 
 fn idy(
@@ -370,7 +370,7 @@ fn idy(
     assert(op_sorted_addr[4] == wrapping_add_u16(addr, 1));
     assert(op_sorted_op_rw[4] == 0);
     let hi = op_sorted_val[4];
-    addr = ((hi as u16) << 8 | lo as u16) as Field;
+    addr = ((hi as u32) << 8 | lo as u32) as Field;
     // Read y value
     assert(op_sorted_addr[5] == 8202);
     assert(op_sorted_op_rw[5] == 0);
@@ -378,7 +378,7 @@ fn idy(
     // set Addr to (addr << 8 | lo) + y
     let abs_addr = wrapping_add_u16(addr, yvalue);
     // read addr & 0xFF00 | Addr & 0x00FF and return as Value
-    let data_addr = ((addr as u16) & 65280) | ((abs_addr as u16) & 255);
+    let data_addr = ((addr as u32) & 65280) | ((abs_addr as u32) & 255);
     assert(op_sorted_addr[6] == data_addr as Field);
     assert(op_sorted_op_rw[6] == 0);
     let data_value = op_sorted_val[6];

--- a/circuits/helpers/src/addressing.nr
+++ b/circuits/helpers/src/addressing.nr
@@ -27,7 +27,7 @@
 //Y = 8202
 //A = 8200
 
-fn wrapping_add_u16(a: Field, b: Field) -> Field {
+pub fn wrapping_add_u16(a: Field, b: Field) -> Field {
     let max = 65535;
 
     if ((a as u32) + (b as u32)) > 65535 {
@@ -38,7 +38,7 @@ fn wrapping_add_u16(a: Field, b: Field) -> Field {
 
 }
 
-fn acc(
+pub fn acc(
     op_sorted_addr: [Field; 1],
     op_sorted_val: [Field; 1],
     op_sorted_op_rw: [Field; 1],
@@ -50,7 +50,7 @@ fn acc(
     // value at PC is read and thrown away
 }
 
-fn imp(
+pub fn imp(
     op_sorted_addr: [Field; 2],
     op_sorted_val: [Field; 2],
     op_sorted_op_rw: [Field; 2],
@@ -64,7 +64,7 @@ fn imp(
     assert(op_sorted_op_rw[1] == 0);
 }
 
-fn imm(
+pub fn imm(
     op_sorted_addr: [Field; 2],
     op_sorted_val: [Field; 2],
     op_sorted_op_rw: [Field; 2],
@@ -82,7 +82,7 @@ fn imm(
     address
 }
 
-fn zpo(
+pub fn zpo(
     op_sorted_addr: [Field; 3],
     op_sorted_val: [Field; 3],
     op_sorted_op_rw: [Field; 3],
@@ -103,7 +103,7 @@ fn zpo(
     value
 }
 
-fn zpx_zpy(
+pub fn zpx_zpy(
     mode: Field,
     op_sorted_addr: [Field; 5],
     op_sorted_val: [Field; 5],
@@ -139,7 +139,7 @@ fn zpx_zpy(
     wrapping_add_u16(value, indexValue)
 }
 
-fn rel(
+pub fn rel(
     op_sorted_addr: [Field; 3],
     op_sorted_val: [Field; 3],
     op_sorted_op_rw: [Field; 3],
@@ -160,7 +160,7 @@ fn rel(
     value
 }
 
-fn abs(
+pub fn abs(
     op_sorted_addr: [Field; 6],
     op_sorted_val: [Field; 6],
     op_sorted_op_rw: [Field; 6],
@@ -192,7 +192,7 @@ fn abs(
     ((hi as u8) << 8 | (lo as u8)) as Field
 }
 
-fn abx_aby(
+pub fn abx_aby(
     mode: Field,
     op_sorted_addr: [Field; 8],
     op_sorted_val: [Field; 8],
@@ -247,7 +247,7 @@ fn abx_aby(
     [abs_addr, op_sorted_val[7]]
 }
 
-fn ind(
+pub fn ind(
     op_sorted_addr: [Field; 8],
     op_sorted_val: [Field; 8],
     op_sorted_op_rw: [Field; 8],
@@ -308,7 +308,7 @@ fn ind(
     }
 }
 
-fn idx(
+pub fn idx(
     op_sorted_addr: [Field; 7],
     op_sorted_val: [Field; 7],
     op_sorted_op_rw: [Field; 7],
@@ -346,7 +346,7 @@ fn idx(
         ((hi as u32) << 8 | (lo as u32)) as Field
 }
 
-fn idy(
+pub fn idy(
     op_sorted_addr: [Field; 7],
     op_sorted_val: [Field; 7],
     op_sorted_op_rw: [Field; 7],

--- a/circuits/helpers/src/lib.nr
+++ b/circuits/helpers/src/lib.nr
@@ -2,18 +2,18 @@ mod addressing;
 mod permutation;
 
 struct Status {
-    C: u16, // Carry
-    Z: u16, // Zero
-    I: u16, // Disable Interrupt
-    D: u16, // Decimal Mode
-    B: u16, // Break
-    U: u16, // Unused
-    V: u16, // Overflow
-    N: u16, // Negative
+    C: u32, // Carry
+    Z: u32, // Zero
+    I: u32, // Disable Interrupt
+    D: u32, // Decimal Mode
+    B: u32, // Break
+    U: u32, // Unused
+    V: u32, // Overflow
+    N: u32, // Negative
 }
 
 unconstrained fn convert_to_status(n: Field) -> Status {
-    let number = n as u16;
+    let number = n as u32;
     let status = Status {
         C: number & 1,
         Z: number & 2,
@@ -28,7 +28,7 @@ unconstrained fn convert_to_status(n: Field) -> Status {
 }
 
 unconstrained fn status_to_num(status: Status) -> Field {
-    let mut number = 0 as u16;
+    let mut number = 0 as u32;
      number = number | status.C & 1;
      number = number | status.Z & 2;
      number = number | status.I & 4;
@@ -66,7 +66,7 @@ struct WrapResult {
 fn wrapping_add_u8(a: Field, b: Field) -> WrapResult {
     let max = 255;
     let result = a + b;
-    if (result as u16 > 255) {
+    if (result as u32 > 255) {
         WrapResult {
             value: 0,
             wrapped: true,

--- a/circuits/helpers/src/lib.nr
+++ b/circuits/helpers/src/lib.nr
@@ -66,7 +66,7 @@ struct WrapResult {
 pub fn wrapping_add_u8(a: Field, b: Field) -> WrapResult {
     let max = 255;
     let result = a + b;
-    if (result as u32 > 255) {
+    if (result as u32 > max) {
         WrapResult {
             value: 0,
             wrapped: true,

--- a/circuits/helpers/src/lib.nr
+++ b/circuits/helpers/src/lib.nr
@@ -12,7 +12,7 @@ struct Status {
     N: u32, // Negative
 }
 
-unconstrained fn convert_to_status(n: Field) -> Status {
+unconstrained pub fn convert_to_status(n: Field) -> Status {
     let number = n as u32;
     let status = Status {
         C: number & 1,
@@ -27,7 +27,7 @@ unconstrained fn convert_to_status(n: Field) -> Status {
     status
 }
 
-unconstrained fn status_to_num(status: Status) -> Field {
+unconstrained pub fn status_to_num(status: Status) -> Field {
     let mut number = 0 as u32;
      number = number | status.C & 1;
      number = number | status.Z & 2;
@@ -40,7 +40,7 @@ unconstrained fn status_to_num(status: Status) -> Field {
      number as Field
 }
 
-fn compute_zn_status(number: Field, mut status: Status) -> Status {
+pub fn compute_zn_status(number: Field, mut status: Status) -> Status {
     // let mut bits = 0 as u8;
     if (number == 0) {
         status.Z = 1;
@@ -54,7 +54,7 @@ fn compute_zn_status(number: Field, mut status: Status) -> Status {
     status
 }
 
-fn wrapping_add_u16(a: Field, b: Field) -> Field {
+pub fn wrapping_add_u16(a: Field, b: Field) -> Field {
     addressing::wrapping_add_u16(a, b)
 }
 
@@ -63,7 +63,7 @@ struct WrapResult {
     wrapped: bool
 }
 
-fn wrapping_add_u8(a: Field, b: Field) -> WrapResult {
+pub fn wrapping_add_u8(a: Field, b: Field) -> WrapResult {
     let max = 255;
     let result = a + b;
     if (result as u32 > 255) {
@@ -79,7 +79,7 @@ fn wrapping_add_u8(a: Field, b: Field) -> WrapResult {
     }
 }
 
-fn acc(
+pub fn acc(
     op_sorted_addr: [Field; 1],
     op_sorted_val: [Field; 1],
     op_sorted_op_rw: [Field; 1],
@@ -90,7 +90,7 @@ fn acc(
         op_sorted_op_rw
     )
 }
-fn imp(
+pub fn imp(
     op_sorted_addr: [Field; 2],
     op_sorted_val: [Field; 2],
     op_sorted_op_rw: [Field; 2],
@@ -101,7 +101,7 @@ fn imp(
         op_sorted_op_rw
     )
 }
-fn imm(
+pub fn imm(
     op_sorted_addr: [Field; 2],
     op_sorted_val: [Field; 2],
     op_sorted_op_rw: [Field; 2],
@@ -112,7 +112,7 @@ fn imm(
         op_sorted_op_rw
     )
 }
-fn zpo(
+pub fn zpo(
     op_sorted_addr: [Field; 3],
     op_sorted_val: [Field; 3],
     op_sorted_op_rw: [Field; 3],
@@ -123,7 +123,7 @@ fn zpo(
         op_sorted_op_rw
     )
 }
-fn zpx_zpy(
+pub fn zpx_zpy(
     mode: Field,
     op_sorted_addr: [Field; 5],
     op_sorted_val: [Field; 5],
@@ -136,7 +136,7 @@ fn zpx_zpy(
         op_sorted_op_rw
     )
 }
-fn rel(
+pub fn rel(
     op_sorted_addr: [Field; 3],
     op_sorted_val: [Field; 3],
     op_sorted_op_rw: [Field; 3],
@@ -147,7 +147,7 @@ fn rel(
         op_sorted_op_rw
     )
 }
-fn abs(
+pub fn abs(
     op_sorted_addr: [Field; 6],
     op_sorted_val: [Field; 6],
     op_sorted_op_rw: [Field; 6],
@@ -158,7 +158,7 @@ fn abs(
         op_sorted_op_rw
     )
 }
-fn abx_aby(
+pub fn abx_aby(
     mode: Field,
     op_sorted_addr: [Field; 8],
     op_sorted_val: [Field; 8],
@@ -171,7 +171,7 @@ fn abx_aby(
         op_sorted_op_rw
     )
 }
-fn ind(
+pub fn ind(
     op_sorted_addr: [Field; 8],
     op_sorted_val: [Field; 8],
     op_sorted_op_rw: [Field; 8],
@@ -182,7 +182,7 @@ fn ind(
         op_sorted_op_rw
     )
 }
-fn idx(
+pub fn idx(
     op_sorted_addr: [Field; 7],
     op_sorted_val: [Field; 7],
     op_sorted_op_rw: [Field; 7],
@@ -193,7 +193,7 @@ fn idx(
         op_sorted_op_rw
     )
 }
-fn idy(
+pub fn idy(
     op_sorted_addr: [Field; 7],
     op_sorted_val: [Field; 7],
     op_sorted_op_rw: [Field; 7],
@@ -205,7 +205,7 @@ fn idy(
     )
 }
 
-fn compute_permutation_9(
+pub fn compute_permutation_9(
     r: Field,
     op_sorted_step: [Field; 9],
     op_sorted_addr: [Field; 9],
@@ -220,7 +220,7 @@ fn compute_permutation_9(
         op_sorted_op_rw
     )
 }
-fn compute_permutation_21(
+pub fn compute_permutation_21(
     r: Field,
     op_sorted_step: [Field; 21],
     op_sorted_addr: [Field; 21],

--- a/circuits/helpers/src/permutation.nr
+++ b/circuits/helpers/src/permutation.nr
@@ -1,5 +1,5 @@
 
-fn compute_21(
+pub fn compute_21(
     r: Field,
     op_sorted_step: [Field; 21],
     op_sorted_addr: [Field; 21],
@@ -10,7 +10,7 @@ fn compute_21(
     0
 }
 
-fn compute_9(
+pub fn compute_9(
     r: Field,
     op_sorted_step: [Field; 9],
     op_sorted_addr: [Field; 9],

--- a/circuits/helpers/src/permutation.nr
+++ b/circuits/helpers/src/permutation.nr
@@ -1,21 +1,21 @@
 
 pub fn compute_21(
-    r: Field,
-    op_sorted_step: [Field; 21],
-    op_sorted_addr: [Field; 21],
-    op_sorted_val: [Field; 21],
-    op_sorted_op_rw: [Field; 21]
+    _r: Field,
+    _op_sorted_step: [Field; 21],
+    _op_sorted_addr: [Field; 21],
+    _op_sorted_val: [Field; 21],
+    _op_sorted_op_rw: [Field; 21]
 ) -> Field {
     // TODO: implement
     0
 }
 
 pub fn compute_9(
-    r: Field,
-    op_sorted_step: [Field; 9],
-    op_sorted_addr: [Field; 9],
-    op_sorted_val: [Field; 9],
-    op_sorted_op_rw: [Field; 9]
+    _r: Field,
+    _op_sorted_step: [Field; 9],
+    _op_sorted_addr: [Field; 9],
+    _op_sorted_val: [Field; 9],
+    _op_sorted_op_rw: [Field; 9]
 ) -> Field {
     // TODO: implement
     0

--- a/circuits/instr/adc/Nargo.toml
+++ b/circuits/instr/adc/Nargo.toml
@@ -2,7 +2,7 @@
 name = "adc"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/ahx/Nargo.toml
+++ b/circuits/instr/ahx/Nargo.toml
@@ -2,7 +2,7 @@
 name = "ahx"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/alr/Nargo.toml
+++ b/circuits/instr/alr/Nargo.toml
@@ -2,7 +2,7 @@
 name = "alr"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/anc/Nargo.toml
+++ b/circuits/instr/anc/Nargo.toml
@@ -2,7 +2,7 @@
 name = "anc"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/and/Nargo.toml
+++ b/circuits/instr/and/Nargo.toml
@@ -2,7 +2,7 @@
 name = "and"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/arr/Nargo.toml
+++ b/circuits/instr/arr/Nargo.toml
@@ -2,7 +2,7 @@
 name = "arr"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/asl/Nargo.toml
+++ b/circuits/instr/asl/Nargo.toml
@@ -2,7 +2,7 @@
 name = "asl"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/axs/Nargo.toml
+++ b/circuits/instr/axs/Nargo.toml
@@ -2,7 +2,7 @@
 name = "axs"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/bcc/Nargo.toml
+++ b/circuits/instr/bcc/Nargo.toml
@@ -2,7 +2,7 @@
 name = "bcc"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/bcs/Nargo.toml
+++ b/circuits/instr/bcs/Nargo.toml
@@ -2,7 +2,7 @@
 name = "bcs"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/beq/Nargo.toml
+++ b/circuits/instr/beq/Nargo.toml
@@ -2,7 +2,7 @@
 name = "beq"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/bit/Nargo.toml
+++ b/circuits/instr/bit/Nargo.toml
@@ -2,7 +2,7 @@
 name = "bit"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/bmi/Nargo.toml
+++ b/circuits/instr/bmi/Nargo.toml
@@ -2,7 +2,7 @@
 name = "bmi"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/bne/Nargo.toml
+++ b/circuits/instr/bne/Nargo.toml
@@ -2,7 +2,7 @@
 name = "bne"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/bpl/Nargo.toml
+++ b/circuits/instr/bpl/Nargo.toml
@@ -2,7 +2,7 @@
 name = "bpl"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/branch/Nargo.toml
+++ b/circuits/instr/branch/Nargo.toml
@@ -2,7 +2,7 @@
 name = "branch"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/brk/Nargo.toml
+++ b/circuits/instr/brk/Nargo.toml
@@ -2,7 +2,7 @@
 name = "brk"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/bvc/Nargo.toml
+++ b/circuits/instr/bvc/Nargo.toml
@@ -2,7 +2,7 @@
 name = "bvc"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/bvs/Nargo.toml
+++ b/circuits/instr/bvs/Nargo.toml
@@ -2,7 +2,7 @@
 name = "bvs"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/clc/Nargo.toml
+++ b/circuits/instr/clc/Nargo.toml
@@ -2,7 +2,7 @@
 name = "clc"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/cld/Nargo.toml
+++ b/circuits/instr/cld/Nargo.toml
@@ -2,7 +2,7 @@
 name = "cld"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/cli/Nargo.toml
+++ b/circuits/instr/cli/Nargo.toml
@@ -2,7 +2,7 @@
 name = "cli"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/clv/Nargo.toml
+++ b/circuits/instr/clv/Nargo.toml
@@ -2,7 +2,7 @@
 name = "clv"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/cmp/Nargo.toml
+++ b/circuits/instr/cmp/Nargo.toml
@@ -2,7 +2,7 @@
 name = "cmp"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/cpx/Nargo.toml
+++ b/circuits/instr/cpx/Nargo.toml
@@ -2,7 +2,7 @@
 name = "cpx"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/cpy/Nargo.toml
+++ b/circuits/instr/cpy/Nargo.toml
@@ -2,7 +2,7 @@
 name = "cpy"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/dcp/Nargo.toml
+++ b/circuits/instr/dcp/Nargo.toml
@@ -2,7 +2,7 @@
 name = "dcp"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/dec/Nargo.toml
+++ b/circuits/instr/dec/Nargo.toml
@@ -2,7 +2,7 @@
 name = "dec"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/dex/Nargo.toml
+++ b/circuits/instr/dex/Nargo.toml
@@ -2,7 +2,7 @@
 name = "dex"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/dey/Nargo.toml
+++ b/circuits/instr/dey/Nargo.toml
@@ -2,7 +2,7 @@
 name = "dey"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/eor/Nargo.toml
+++ b/circuits/instr/eor/Nargo.toml
@@ -2,7 +2,7 @@
 name = "eor"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/ign/Nargo.toml
+++ b/circuits/instr/ign/Nargo.toml
@@ -2,7 +2,7 @@
 name = "ign"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/inc/Nargo.toml
+++ b/circuits/instr/inc/Nargo.toml
@@ -2,7 +2,7 @@
 name = "inc"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/inx/Nargo.toml
+++ b/circuits/instr/inx/Nargo.toml
@@ -2,7 +2,7 @@
 name = "inx"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/iny/Nargo.toml
+++ b/circuits/instr/iny/Nargo.toml
@@ -2,7 +2,7 @@
 name = "iny"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/isb/Nargo.toml
+++ b/circuits/instr/isb/Nargo.toml
@@ -2,7 +2,7 @@
 name = "isb"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/jmp/Nargo.toml
+++ b/circuits/instr/jmp/Nargo.toml
@@ -2,7 +2,7 @@
 name = "jmp"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/jsr/Nargo.toml
+++ b/circuits/instr/jsr/Nargo.toml
@@ -2,7 +2,7 @@
 name = "jsr"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/las/Nargo.toml
+++ b/circuits/instr/las/Nargo.toml
@@ -2,7 +2,7 @@
 name = "las"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/lax/Nargo.toml
+++ b/circuits/instr/lax/Nargo.toml
@@ -2,7 +2,7 @@
 name = "lax"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/lda/Nargo.toml
+++ b/circuits/instr/lda/Nargo.toml
@@ -2,7 +2,7 @@
 name = "lda"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/ldx/Nargo.toml
+++ b/circuits/instr/ldx/Nargo.toml
@@ -2,7 +2,7 @@
 name = "ldx"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/ldy/Nargo.toml
+++ b/circuits/instr/ldy/Nargo.toml
@@ -2,7 +2,7 @@
 name = "ldy"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/lsr/Nargo.toml
+++ b/circuits/instr/lsr/Nargo.toml
@@ -2,7 +2,7 @@
 name = "lsr"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/nop/Nargo.toml
+++ b/circuits/instr/nop/Nargo.toml
@@ -2,7 +2,7 @@
 name = "nop"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/ora/Nargo.toml
+++ b/circuits/instr/ora/Nargo.toml
@@ -2,7 +2,7 @@
 name = "ora"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/pha/Nargo.toml
+++ b/circuits/instr/pha/Nargo.toml
@@ -2,7 +2,7 @@
 name = "pha"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/php/Nargo.toml
+++ b/circuits/instr/php/Nargo.toml
@@ -2,7 +2,7 @@
 name = "php"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/pla/Nargo.toml
+++ b/circuits/instr/pla/Nargo.toml
@@ -2,7 +2,7 @@
 name = "pla"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/plp/Nargo.toml
+++ b/circuits/instr/plp/Nargo.toml
@@ -2,7 +2,7 @@
 name = "plp"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/rla/Nargo.toml
+++ b/circuits/instr/rla/Nargo.toml
@@ -2,7 +2,7 @@
 name = "rla"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/rol/Nargo.toml
+++ b/circuits/instr/rol/Nargo.toml
@@ -2,7 +2,7 @@
 name = "rol"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/ror/Nargo.toml
+++ b/circuits/instr/ror/Nargo.toml
@@ -2,7 +2,7 @@
 name = "ror"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/rra/Nargo.toml
+++ b/circuits/instr/rra/Nargo.toml
@@ -2,7 +2,7 @@
 name = "rra"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/rti/Nargo.toml
+++ b/circuits/instr/rti/Nargo.toml
@@ -2,7 +2,7 @@
 name = "rti"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/rts/Nargo.toml
+++ b/circuits/instr/rts/Nargo.toml
@@ -2,7 +2,7 @@
 name = "rts"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/sax/Nargo.toml
+++ b/circuits/instr/sax/Nargo.toml
@@ -2,7 +2,7 @@
 name = "sax"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/sbc/Nargo.toml
+++ b/circuits/instr/sbc/Nargo.toml
@@ -2,7 +2,7 @@
 name = "sbc"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/sec/Nargo.toml
+++ b/circuits/instr/sec/Nargo.toml
@@ -2,7 +2,7 @@
 name = "sec"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/sed/Nargo.toml
+++ b/circuits/instr/sed/Nargo.toml
@@ -2,7 +2,7 @@
 name = "sed"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/sei/Nargo.toml
+++ b/circuits/instr/sei/Nargo.toml
@@ -2,7 +2,7 @@
 name = "sei"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/skb/Nargo.toml
+++ b/circuits/instr/skb/Nargo.toml
@@ -2,7 +2,7 @@
 name = "skb"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/slo/Nargo.toml
+++ b/circuits/instr/slo/Nargo.toml
@@ -2,7 +2,7 @@
 name = "slo"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/sre/Nargo.toml
+++ b/circuits/instr/sre/Nargo.toml
@@ -2,7 +2,7 @@
 name = "sre"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/sta/Nargo.toml
+++ b/circuits/instr/sta/Nargo.toml
@@ -2,7 +2,7 @@
 name = "sta"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/stx/Nargo.toml
+++ b/circuits/instr/stx/Nargo.toml
@@ -2,7 +2,7 @@
 name = "stx"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/sty/Nargo.toml
+++ b/circuits/instr/sty/Nargo.toml
@@ -2,7 +2,7 @@
 name = "sty"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/sxa/Nargo.toml
+++ b/circuits/instr/sxa/Nargo.toml
@@ -2,7 +2,7 @@
 name = "sxa"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/sya/Nargo.toml
+++ b/circuits/instr/sya/Nargo.toml
@@ -2,7 +2,7 @@
 name = "sya"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/tas/Nargo.toml
+++ b/circuits/instr/tas/Nargo.toml
@@ -2,7 +2,7 @@
 name = "tas"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/tax/Nargo.toml
+++ b/circuits/instr/tax/Nargo.toml
@@ -2,7 +2,7 @@
 name = "tax"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/tay/Nargo.toml
+++ b/circuits/instr/tay/Nargo.toml
@@ -2,7 +2,7 @@
 name = "tay"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/tsx/Nargo.toml
+++ b/circuits/instr/tsx/Nargo.toml
@@ -2,7 +2,7 @@
 name = "tsx"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/txa/Nargo.toml
+++ b/circuits/instr/txa/Nargo.toml
@@ -2,7 +2,7 @@
 name = "txa"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/txs/Nargo.toml
+++ b/circuits/instr/txs/Nargo.toml
@@ -2,7 +2,7 @@
 name = "txs"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/tya/Nargo.toml
+++ b/circuits/instr/tya/Nargo.toml
@@ -2,7 +2,7 @@
 name = "tya"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/xaa/Nargo.toml
+++ b/circuits/instr/xaa/Nargo.toml
@@ -2,7 +2,7 @@
 name = "xaa"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/instr/xxx/Nargo.toml
+++ b/circuits/instr/xxx/Nargo.toml
@@ -2,7 +2,7 @@
 name = "xxx"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/memory/Nargo.toml
+++ b/circuits/memory/Nargo.toml
@@ -2,6 +2,6 @@
 name = "memory"
 authors = ["Goblin Oats"]
 type = "bin"
-compiler_version = "0.9.0"
+compiler_version = ">=0.9.0"
 
 [dependencies]

--- a/circuits/scripts/bootstrap_opcodes.js
+++ b/circuits/scripts/bootstrap_opcodes.js
@@ -79,7 +79,7 @@ fn check_op(
 name = "${name}"
 type = "bin"
 authors = [""]
-compiler_version = "0.10.5"
+compiler_version = ">=0.10.5"
 
 [dependencies]
 helpers = { path = "../../helpers" }

--- a/circuits/scripts/convert_emulator_trace.js
+++ b/circuits/scripts/convert_emulator_trace.js
@@ -61,7 +61,7 @@ function convertSegment(segment) {
 function templateSegment(segmentData, index) {
     return `
 #[test]
-fn test_${index}() {
+fn test_${index}() -> Field {
     main(
         1, 
         [${segmentData.step.join(", ")}], 

--- a/emulator/web/Cargo.lock
+++ b/emulator/web/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.9.0"
+version = ">=0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
 dependencies = [


### PR DESCRIPTION
I still get compiler issues and warning with last version of Noir. This PR fixes them:

0) make toml files compatible with more recent version of compiler

1) u16 type doesn't seem to exist anymore
<img width="995" alt="image" src="https://github.com/tonk-gg/dappicom/assets/1172099/7d26ddaa-e94e-4d16-b9a8-7f5e19fd0bc5">

2) helper functions are not public
<img width="768" alt="image" src="https://github.com/tonk-gg/dappicom/assets/1172099/f0092624-ab7d-4907-becb-f22efa6bac66">

3) some useful variables are unused (eg: max)

4) some unused variables should be declared as such